### PR TITLE
Fixed a mis-typed "context" keyword in the spec file

### DIFF
--- a/gem_city_spec.rb
+++ b/gem_city_spec.rb
@@ -43,7 +43,7 @@ describe 'Gem City' do
     end
   end
 
-  # contex 'city_demographics' do
+  # context 'city_demographics' do
   #   it 'initialize' do
   #     demographics = city.city_demographics
   #     expect(demographics[:thieves]).to eq('10%')


### PR DESCRIPTION
Simple fix for a problem i ran into when going through the tests myself.
